### PR TITLE
Room timeout

### DIFF
--- a/server/Room.js
+++ b/server/Room.js
@@ -192,6 +192,9 @@ function Room(roomCode, testing) {
             //Update the room service of every user
             self.broadcastRoom("ROOM details");
             self.broadcastRoom('ROOM messages');
+
+            // if there is any time to live timer set, cancel it now
+            self.clearTimeToLiveTimer();
         }
 
         // Return wether the join was successful or not
@@ -211,18 +214,15 @@ function Room(roomCode, testing) {
         If a user joins the room before the timeout expires, clears this timer
     */
     self.setTimeToLiveTimer = function(callback) {
-        console.log("setting time to live");
-        self.timeToLiveTimer = setTimeout(callback, 1000);
+        var timeToLive = 10000;
+        console.log("setting time to live" + timeToLive);
+        self.timeToLiveTimer = setTimeout(callback, timeToLive);
     };
 
     self.clearTimeToLiveTimer = function() {
+        console.log("clearing time to live");
         clearTimeout(self.timeToLiveTimer);
     };
-
-    self.deleteRoom = function() {
-        console.log("ROOM DELETED " + self.id);
-    };
-
 
     self.removeUser = function(user) {
 

--- a/server/Room.js
+++ b/server/Room.js
@@ -7,6 +7,7 @@ function Room(roomCode, testing) {
     self.gameController = undefined;
     self.botsInRoom = [];
     self.messages = [];
+    self.timeToLiveTimer = undefined;
 
     if (testing === undefined) {
         self.numRounds = 8;
@@ -199,6 +200,27 @@ function Room(roomCode, testing) {
             userAlreadyInRoom: userAlreadyInRoom,
             joined: canJoin
         };
+    };
+
+    /*
+        Delete the room after a set amount of time
+
+        When a room is empty, and the last user has left, sets a timer that
+        will delete the room after N seconds.
+
+        If a user joins the room before the timeout expires, clears this timer
+    */
+    self.setTimeToLiveTimer = function(callback) {
+        console.log("setting time to live");
+        self.timeToLiveTimer = setTimeout(callback, 1000);
+    };
+
+    self.clearTimeToLiveTimer = function() {
+        clearTimeout(self.timeToLiveTimer);
+    };
+
+    self.deleteRoom = function() {
+        console.log("ROOM DELETED " + self.id);
     };
 
 

--- a/server/Room.js
+++ b/server/Room.js
@@ -8,6 +8,8 @@ function Room(roomCode, testing) {
     self.botsInRoom = [];
     self.messages = [];
     self.timeToLiveTimer = undefined;
+    self.timeToLive = 15000; // amount of time the room will persist with no-one it it
+
 
     if (testing === undefined) {
         self.numRounds = 8;
@@ -86,15 +88,15 @@ function Room(roomCode, testing) {
 
 
     /*
-    Attempts to put a user in the room
+        Attempts to put a user in the room
 
-    Does not put the user in if
-        They are already in it
-        A game has started and they were not previosuly in that game
+        Does not put the user in if
+            They are already in it
+            A game has started and they were not previosuly in that game
 
-    If force is true, it will let the user join
-        this lets observers join games in progress
-*/
+        If force is true, it will let the user join
+            this lets observers join games in progress
+    */
     self.addUser = function(user, testing, forceUserInRoom) {
 
         var canJoin = true;
@@ -214,13 +216,10 @@ function Room(roomCode, testing) {
         If a user joins the room before the timeout expires, clears this timer
     */
     self.setTimeToLiveTimer = function(callback) {
-        var timeToLive = 10000;
-        console.log("setting time to live" + timeToLive);
-        self.timeToLiveTimer = setTimeout(callback, timeToLive);
+        self.timeToLiveTimer = setTimeout(callback, self.timeToLive);
     };
 
     self.clearTimeToLiveTimer = function() {
-        console.log("clearing time to live");
         clearTimeout(self.timeToLiveTimer);
     };
 

--- a/server/server.js
+++ b/server/server.js
@@ -181,7 +181,6 @@ module.exports = function(port, enableLogging, testing) {
 
             if (room !== undefined) {
                 removeUserFromRoom(room);
-                room.broadcastRoom('ROOM details');
             }
 
             if (!user.isObserver) {
@@ -527,26 +526,12 @@ module.exports = function(port, enableLogging, testing) {
 
             if (room !== undefined) {
                 // Take the user out of the game (set as disconnected)
-                // room.removeUser(user);
                 removeUserFromRoom(room);
 
                 if (!user.isObserver) {
                     user.readyToProceed = false;
                 }
 
-                // console.log("people in room" + room.usersInRoom.length);
-
-                // // Check if anyone is still in the room
-                // // if not, start expiriy timer
-                // if (room.usersInRoom.length === 0) {
-                //     room.setTimeToLiveTimer(function() {
-                //         deleteRoom(room);
-                //         console.log(rooms);
-                //         logger.debug("No-one in room" + room.id + ", deleting it");
-                //     });
-                // }
-
-                // logger.debug("Removing player from room" + room.id);
             } else {
                 logger.debug("User was not in a room");
             }

--- a/server/server.js
+++ b/server/server.js
@@ -503,6 +503,9 @@ module.exports = function(port, enableLogging, testing) {
             so that he can join again
 
             Takes the user out of the game if they were in one
+
+            If there is no-one left in the room, will set a time to live for the room
+            so we can delete it if no-one rejoins
         */
         socket.on('disconnect', function() {
 
@@ -515,6 +518,16 @@ module.exports = function(port, enableLogging, testing) {
                 if (!user.isObserver) {
                     user.readyToProceed = false;
                 }
+
+                // Check if anyone is still in the room
+                // if not, start expiriy timer
+                if(room.usersInRoom.length === 0) {
+                    room.setTimeToLiveTimer(function() {
+                        console.log("ROOM DELETED " + room.id);
+                    });
+                }
+
+
 
                 logger.debug("Removing player from room" + room.id);
             } else {

--- a/test/e2e/observerSpec.js
+++ b/test/e2e/observerSpec.js
@@ -23,12 +23,12 @@ describe('When playing as a observer', function() {
 		secondClonageUser.getIndex();
 		secondClonageUser.submitName('Alice');
 		secondClonageUser.createRoom();
-		expect(firstClonageUser.element.all(by.repeater('room in allRoomsAvailable()')).count()).toBe(10);
+		expect(firstClonageUser.element.all(by.repeater('room in allRoomsAvailable()')).count()).toBeGreaterThan(0); // don't know how many rooms will have timed out by this point
 	});
 
 	it('Can refresh and still see all the rooms available', function() {
 		firstClonageUser.refresh();
-		expect(firstClonageUser.element.all(by.repeater('room in allRoomsAvailable()')).count()).toBe(10);
+		expect(firstClonageUser.element.all(by.repeater('room in allRoomsAvailable()')).count()).toBeGreaterThan(0);
 
 	});
 


### PR DESCRIPTION
When the last user leaves the room, the room sets a time out to be deleted, (15s). When the time runs out, the room is removed from the rooms list (essentially unreachable from then on). 
If someone joins the empty room before the timeout expires, the timer is cleared and every thing is back to normal :)

Fixes the problem where rooms persisted forever on the server, and the observer could see all the historic rooms.