### PR TITLE
Fix bot answers not being sent when timer ran out

### DIFF
--- a/server/GameController.js
+++ b/server/GameController.js
@@ -171,6 +171,8 @@ module.exports = function(data) {
 		var data;
 		var deferred = Q.defer();
 
+		setRank();
+
 		// Check if game over
 		if (gameOver) {
 
@@ -462,6 +464,7 @@ module.exports = function(data) {
 				bot.updateHand(randomAns);
 				randomAnswers.push(randomAns);
 			}
+
 			round.addSubmission(bot, randomAnswers);
 		});
 	};

--- a/server/server.js
+++ b/server/server.js
@@ -335,7 +335,7 @@ module.exports = function(port, enableLogging, testing) {
 
             // Set up the gameController
             // Will start the first round once initialized
-           room.gameController.initialize(room).then(function(initialResults) {
+            room.gameController.initialize(room).then(function(initialResults) {
 
                 room.broadcastRoom("GAME playerRoundResults", {
                     results: initialResults,
@@ -421,8 +421,13 @@ module.exports = function(port, enableLogging, testing) {
                     // and wait until it has ran out (triggers a callback)
                     room.gameController.startTimer(testing, function(data) {
 
-                        // time has ran out so everyone is routed to the voting page
+                        room.broadcastRoom("GAME roundSubmissionData", {
+                            roundSubmissionData: data.roundSubmissionData,
+                            currentNumberOfSubmissions: data.currentNumberOfSubmissions,
+                            currentNumberOfVotes: data.currentNumberOfVotes
+                        });
 
+                        // time has ran out so everyone is routed to the voting page
                         putUserInVote(room);
                     });
                 }


### PR DESCRIPTION
When the timer ran out, the final submission data was not sent back to the server, as it was presumed to have been sent when every player submitted a vote.

However, if not all players submitted,  and the timer ran out, bot answers WERE added  to the round object (when changing the game state) but the updated round info was never sent back to the client.

By sending this info again when the timer runs out, we can now see the bot answers.