### PR TITLE
Answer visualise order bug fix

### DIFF
--- a/client/Angular/controllers/gameController.js
+++ b/client/Angular/controllers/gameController.js
@@ -30,9 +30,18 @@ ClonageApp.controller("gameController", function($scope, $timeout, $window, $sce
 
     //get all answers submitted in order to visualise them on the voting page
     $scope.visualiseAnswers = function() {
-        var ans = gameService.getAnswersToVisualise().filter(function(submission){
+        var ans = gameService.getAnswersToVisualise().filter(function(submission) {
             return submission.submissionsText.length > 0;
         });
+
+        ans.sort(function(a, b) {
+            if (a.submissionsText[0] < b.submissionsText[0])
+                return -1;
+            if (a.submissionsText[0] > b.submissionsText[0])
+                return 1;
+            return 0;
+        })
+
         var filtered = [];
 
         if ($scope.index < gameService.getCurrentNumberOfSubmissions()) {


### PR DESCRIPTION
Fixes bug where the answers were always visualized in the same order and so you could tell who submitted what.
Now it just sorts the submissions alphabetically before they are pushed to the visualization array so they are displayed in the same order as when they can be selected.
